### PR TITLE
Fix Auth0 logout for non-default URLs.

### DIFF
--- a/ui/src/components/AppBarActions.js
+++ b/ui/src/components/AppBarActions.js
@@ -10,7 +10,9 @@ export default function AppBarActions() {
     let authComponent = isAuthenticated ? <>
         <Tooltip title="Logout" aria-label="logout">
             <Avatar src={user.picture} style={authComponentStyle}
-                    onClick={() => logout()}/>
+                    onClick={() => logout({
+                        returnTo: window.location.protocol + '//' + window.location.host
+                    })}/>
         </Tooltip>
     </> : <>
         <Button variant="contained" color="white" disableElevation


### PR DESCRIPTION
This adds the returnTo argument to a call to Auth0's logout function. If we don't specify this, Auth0 will redirect to the default URL for the application, which in this case is http://localhost:3000. This breaks any installation that isn't located at this URL.