### PR TITLE
ui: Fix 404 for non-root paths. Fixes #154.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .idea/
 
 ui/node_modules/
+ui/.env.*
 
 *.db
 

--- a/images/ui/Dockerfile
+++ b/images/ui/Dockerfile
@@ -17,3 +17,7 @@ FROM nginx:mainline
 
 # Copy over static files from npm to nginx.
 COPY --from=npm /app/build /usr/share/nginx/html
+
+# Remove default NGINX config and replace it with ours.
+RUN rm /etc/nginx/conf.d/default.conf
+COPY images/ui/nginx.conf /etc/nginx/conf.d

--- a/images/ui/nginx.conf
+++ b/images/ui/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    # Listen on port 80.
+    listen 80;
+
+    # Serve index.html regardless of the path requested.
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Add 500 errors as normal.
+    error_page 500 502 503 504 /50x.html;
+    location = /50x.html {
+        root  /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
Fixes a 404 issue when the initial path requested from the web server is not the root index page. This was fixed by changing the default NGINX configuration to route everything to the React index.html, where the React Router will then handle the routing on the client-side.