### PR TITLE
Update OpenAPI spec to add new top challenges API.

### DIFF
--- a/frontend/api.yaml
+++ b/frontend/api.yaml
@@ -3,9 +3,9 @@ openapi: 3.0.1
 info:
   title: CTF Frontend API
   description: Frontend API for querying challenge sets, challenges, etc. from the CTF platform.
-  version: 0.1.0
+  version: 0.2.0
 servers:
-  - url: '/'
+  - url: 'https://ctf.cyberliteracyforall.com'
 paths:
   /api/challenge-sets:
     get:
@@ -101,6 +101,15 @@ paths:
             text/markdown: {}
         '404':
           description: Documentation was not found
+  /api/top-challenges:
+    get:
+      responses:
+        '200':
+          description: List of top challenges
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChallengePlayCountList'
   /api/user/environments:
     get:
       security:
@@ -180,6 +189,24 @@ components:
                 type: string
               order:
                 type: integer
+    ChallengePlayCount:
+      type: object
+      required:
+        - challengeSet
+        - challenge
+        - playCount
+      properties:
+        challengeSet:
+          $ref: '#/components/schemas/ChallengeSet'
+        challenge:
+          $ref: '#/components/schemas/Challenge'
+        playCount:
+          type: integer
+    ChallengePlayCountList:
+      type: array
+      maxItems: 5
+      items:
+        $ref: '#/components/schemas/ChallengePlayCount'
     UserEnvironmentInfo:
       type: object
       properties:


### PR DESCRIPTION
This simply adds the new top challenges API call to the OpenAPI spec in our repository. No need to test or generate it, it's purely for reference.

Closes #158.