### PR TITLE
Add admin upload challenge set page.

### DIFF
--- a/challenges/pentesting/challenge-set.json
+++ b/challenges/pentesting/challenge-set.json
@@ -2,7 +2,7 @@
   "$schema": "../schemas/challenge-set.schema.json",
   "id": "4040a75a-037c-44c0-b1e2-bdcc6ceaddb0",
   "slug": "pentesting",
-  "name": "pentesting",
+  "name": "Penetration Testing",
   "description": "Challenge set that focuses on Penetration Testing Utilities",
   "version": "0.1.0",
   "challenges": [

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -9,6 +9,7 @@ import ChallengeBar from "./components/AppBar";
 import Selection from "./pages/Selection.js"
 import Home from "./pages/Home";
 import leaderboard from "./pages/LeaderBoard";
+import UploadChallengeSet from "./pages/admin/UploadChallengeSet";
 /********************************************** Dynamic Pages *******************************************************************/
 import ChallengePage from "./pages/ChallengePage";
 import StartChallengePage from "./pages/StartChallengePage";
@@ -45,6 +46,9 @@ export default function App() {
             <Route path="/env/:csSlug/:cSlug/:envId">
               <ChallengePage/>
             </Route>
+
+            {/* Administration pages */}
+            <Route path="/admin/upload" component={UploadChallengeSet}/>
           </Switch>
         </div>
       </div>

--- a/ui/src/components/Menu.js
+++ b/ui/src/components/Menu.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import AppBar from '@material-ui/core/AppBar';
 import CssBaseline from '@material-ui/core/CssBaseline';
@@ -17,6 +17,7 @@ import {staticMenuData} from './MenuBarData';
 import {Link} from 'react-router-dom';
 import SubMenu from './SubMenu.js';
 import useFetchAuth from "../useFetchAuth";
+import {useAuth0} from "@auth0/auth0-react";
 
 const drawerWidth = 280;
 
@@ -57,10 +58,23 @@ function ResponsiveDrawer(props) {
   const theme = useTheme();
   const [mobileOpen, setMobileOpen] = React.useState(false);
   const [displayFlagSubmit, setDisplayFlagSubmit ] = useState(false);
+  const [isAdmin, setAdmin] = useState(false);
+  const {getIdTokenClaims} = useAuth0();
 
   // API GET REQUEST For items that shows up in the menu list
   // TODO: Handle error/loading states.
   const { data, error, loading } = useFetchAuth(APIpath);
+
+  useEffect(() => {
+    async function queryAdmin() {
+      let claims = await getIdTokenClaims();
+      let roles = claims["http://acasictf.org/roles"] || [];
+      let isAdmin = roles.includes("Administrator");
+      setAdmin(isAdmin);
+    }
+
+    queryAdmin();
+  });
 
   const handleDrawerToggle = () => {
     setMobileOpen(!mobileOpen);
@@ -80,7 +94,12 @@ function ResponsiveDrawer(props) {
         {/* /* LIST 1 */}
         {/* Data in this list is read from local file */}
         <core.List>
-          {staticMenuData.map((item,index)=>{return(
+          {staticMenuData.map((item,index)=>{
+            if (item.adminOnly === true && !isAdmin) {
+              return null;
+            }
+
+            return (
               <core.ListItem button key={index} style={{display:'flex', flexDirection:'column', alignItems:'flex-start'}}>
                   <Link to={item.path} style={{textDecoration:'none'}} onClick={resetFlagSubmit} >
                       <div style={{display:'flex', flexDirection: 'row'}}>

--- a/ui/src/components/MenuBarData.js
+++ b/ui/src/components/MenuBarData.js
@@ -1,6 +1,8 @@
 import * as UI from '@material-ui/icons';
+
 export const staticMenuData = [
     {name:'Home', path:'/', icon: <UI.Home/>, cName:'nav-text'},
     {name:'Leader Board', path:'/LeaderBoard', icon: <UI.Timeline/>, cName:'nav-text'},
-    {name:'Challenge Selection', path:'/selection', icon:<UI.ViewCarousel/>, cName:'nav-text'}
+    {name:'Challenge Selection', path:'/selection', icon:<UI.ViewCarousel/>, cName:'nav-text'},
+    {name:'Upload Challenge Set', path:'/admin/upload', icon:<UI.Unarchive/>, cName:'nav-text', adminOnly: true},
 ]

--- a/ui/src/pages/admin/UploadChallengeSet.js
+++ b/ui/src/pages/admin/UploadChallengeSet.js
@@ -3,14 +3,8 @@ import Button from "@material-ui/core/Button";
 import {useState} from "react";
 
 export default function UploadChallengeSet() {
-  const {isAuthenticated, getAccessTokenSilently} = useAuth0();
+  const {getAccessTokenSilently} = useAuth0();
   const [file, setFile] = useState(null);
-
-  if (!isAuthenticated) {
-    return <div>
-      <h1>Permission denied</h1>
-    </div>;
-  }
 
   return <div>
     <h1>Upload Challenge Set</h1>

--- a/ui/src/pages/admin/UploadChallengeSet.js
+++ b/ui/src/pages/admin/UploadChallengeSet.js
@@ -1,0 +1,56 @@
+import {useAuth0} from "@auth0/auth0-react";
+import Button from "@material-ui/core/Button";
+import {useState} from "react";
+
+export default function UploadChallengeSet() {
+  const {isAuthenticated, getAccessTokenSilently} = useAuth0();
+  const [file, setFile] = useState(null);
+
+  if (!isAuthenticated) {
+    return <div>
+      <h1>Permission denied</h1>
+    </div>;
+  }
+
+  return <div>
+    <h1>Upload Challenge Set</h1>
+
+    <Button
+        variant="contained"
+        component="label"
+    >
+      Choose File
+      <input
+          type="file"
+          hidden
+          onChange={(event) => {
+            setFile(event.target.files[0]);
+          }}
+      />
+    </Button>
+    <Button variant="contained" onClick={async () => {
+      let accessToken = await getAccessTokenSilently();
+
+      let formData = new FormData();
+      formData.append("file", file);
+
+      fetch("/api/admin/challenge-sets", {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${accessToken}`
+        },
+        body: formData,
+      }).then((resp) => {
+        if (resp.status >= 400) {
+          window.alert(`Status >= 400: ${resp.status}`);
+        } else {
+          window.alert("Uploaded successfully!");
+        }
+      }).catch((e) => {
+        window.alert(`Exception: ${e}`);
+      })
+    }}>
+      Upload
+    </Button>
+  </div>;
+}


### PR DESCRIPTION
This pull request adds a hidden page that is only shown to admins. This works by getting the ID token from Auth0, and checking whether the set of roles contains Administrator. If so, it will add a "Upload Challenge Set" menu bar item on the sidebar. This page will show the user a couple of buttons to select a file, then proceed to upload it.

# Related issues
Closes #122.
Closes #10.

# Before
Before this was implemented, I was manually using a curl command to upload these by copying the access token from the browser.

```
curl -XPOST -F file=@pentesting.zip https://ctf.cyberliteracyforall.com/api/admin/challenge-sets -H "Authorization: Bearer $ACCESS_TOKEN"
```

# After
![image](https://user-images.githubusercontent.com/1173922/142706914-79ae47d1-1b81-404a-9f60-62909140d926.png)

# Future work
* Might be good to clean up the page in the future, it's pretty ugly at the moment. Given that it's not a page that is accessible by normal users, I think it's mostly fine for the time being.