### PR TITLE
Separate cipher challenge images.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,12 @@ all: proto docker
 
 proto: $(PROTOSRC)
 docker: docker_penimage docker_termproxy docker_ui docker_frontend docker_operatorkt
-docker_challenges: docker_challenge_cipher docker_challenge_games_noughts \
-				   docker_challenge_games_prize docker_challenge_games_rps \
-				   docker_challenge_games_seven_up docker_challenge_games_yahtzee
+docker_challenges: docker_challenge_cipher_caesar docker_challenge_cipher_comprehensive \
+				   docker_challenge_cipher_letter_number docker_challenge_cipher_morse \
+				   docker_challenge_cipher_reverse \
+				   docker_challenge_games_noughts docker_challenge_games_prize \
+   				   docker_challenge_games_rps docker_challenge_games_seven_up \
+   				   docker_challenge_games_yahtzee
 
 $(PROTOSRC): %:%.proto
 	mkdir -p pb/
@@ -54,10 +57,34 @@ ifeq ($(DOCKER_PUSH), 1)
 		docker push $(IMAGE_CTF_BASE)/frontend:$(IMAGE_TAG)
 endif
 
-docker_challenge_cipher:
-	docker build -t $(IMAGE_CHALLENGES_BASE)/ciphers:$(IMAGE_TAG) -f images/challenges/ciphers/Dockerfile .
+docker_challenge_cipher_caesar:
+	docker build -t $(IMAGE_CHALLENGES_BASE)/ciphers/caesar:$(IMAGE_TAG) -f images/challenges/ciphers/caesar/Dockerfile .
 ifeq ($(DOCKER_PUSH), 1)
-		docker push $(IMAGE_CHALLENGES_BASE)/ciphers:$(IMAGE_TAG)
+		docker push $(IMAGE_CHALLENGES_BASE)/ciphers/caesar:$(IMAGE_TAG)
+endif
+
+docker_challenge_cipher_comprehensive:
+	docker build -t $(IMAGE_CHALLENGES_BASE)/ciphers/comprehensive:$(IMAGE_TAG) -f images/challenges/ciphers/comprehensive/Dockerfile .
+ifeq ($(DOCKER_PUSH), 1)
+		docker push $(IMAGE_CHALLENGES_BASE)/ciphers/comprehensive:$(IMAGE_TAG)
+endif
+
+docker_challenge_cipher_letter_number:
+	docker build -t $(IMAGE_CHALLENGES_BASE)/ciphers/letter-number:$(IMAGE_TAG) -f images/challenges/ciphers/letter-number/Dockerfile .
+ifeq ($(DOCKER_PUSH), 1)
+		docker push $(IMAGE_CHALLENGES_BASE)/ciphers/letter-number:$(IMAGE_TAG)
+endif
+
+docker_challenge_cipher_morse:
+	docker build -t $(IMAGE_CHALLENGES_BASE)/ciphers/morse:$(IMAGE_TAG) -f images/challenges/ciphers/morse/Dockerfile .
+ifeq ($(DOCKER_PUSH), 1)
+		docker push $(IMAGE_CHALLENGES_BASE)/ciphers/morse:$(IMAGE_TAG)
+endif
+
+docker_challenge_cipher_reverse:
+	docker build -t $(IMAGE_CHALLENGES_BASE)/ciphers/reverse:$(IMAGE_TAG) -f images/challenges/ciphers/reverse/Dockerfile .
+ifeq ($(DOCKER_PUSH), 1)
+		docker push $(IMAGE_CHALLENGES_BASE)/ciphers/reverse:$(IMAGE_TAG)
 endif
 
 docker_challenge_games_noughts:

--- a/challenges/ciphers/challenges/caesar-cipher/template.yaml
+++ b/challenges/ciphers/challenges/caesar-cipher/template.yaml
@@ -11,7 +11,7 @@ spec:
       spec:
         containers:
           - name: penimage
-            image: ghcr.io/acasi-ctf/challenges/ciphers:latest
+            image: ghcr.io/acasi-ctf/challenges/ciphers/caesar:latest
   services:
     - metadata:
         name: penimage-termproxy

--- a/challenges/ciphers/challenges/comprehensive-challenge/template.yaml
+++ b/challenges/ciphers/challenges/comprehensive-challenge/template.yaml
@@ -11,7 +11,7 @@ spec:
       spec:
         containers:
           - name: penimage
-            image: ghcr.io/acasi-ctf/challenges/ciphers:latest
+            image: ghcr.io/acasi-ctf/challenges/ciphers/comprehensive:latest
   services:
     - metadata:
         name: penimage-termproxy

--- a/challenges/ciphers/challenges/letter-to-number/template.yaml
+++ b/challenges/ciphers/challenges/letter-to-number/template.yaml
@@ -11,7 +11,7 @@ spec:
       spec:
         containers:
           - name: penimage
-            image: ghcr.io/acasi-ctf/challenges/ciphers:latest
+            image: ghcr.io/acasi-ctf/challenges/ciphers/letter-number:latest
   services:
     - metadata:
         name: penimage-termproxy

--- a/challenges/ciphers/challenges/morse-code/template.yaml
+++ b/challenges/ciphers/challenges/morse-code/template.yaml
@@ -11,7 +11,7 @@ spec:
       spec:
         containers:
           - name: penimage
-            image: ghcr.io/acasi-ctf/challenges/ciphers:latest
+            image: ghcr.io/acasi-ctf/challenges/ciphers/morse:latest
   services:
     - metadata:
         name: penimage-termproxy

--- a/challenges/ciphers/challenges/reverse-cipher/template.yaml
+++ b/challenges/ciphers/challenges/reverse-cipher/template.yaml
@@ -11,7 +11,7 @@ spec:
       spec:
         containers:
           - name: penimage
-            image: ghcr.io/acasi-ctf/challenges/ciphers:latest
+            image: ghcr.io/acasi-ctf/challenges/ciphers/reverse:latest
   services:
     - metadata:
         name: penimage-termproxy

--- a/images/challenges/ciphers/caesar/Dockerfile
+++ b/images/challenges/ciphers/caesar/Dockerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/acasi-ctf/ctf/penimage:latest
+
+COPY challenges/ciphers/challenges/caesar-cipher/code/Caesar-cipher.py /home/player

--- a/images/challenges/ciphers/comprehensive/Dockerfile
+++ b/images/challenges/ciphers/comprehensive/Dockerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/acasi-ctf/ctf/penimage:latest
+
+COPY challenges/ciphers/challenges/comprehensive-challenge/code/Mixed-Challenge-1.py /home/player

--- a/images/challenges/ciphers/letter-number/Dockerfile
+++ b/images/challenges/ciphers/letter-number/Dockerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/acasi-ctf/ctf/penimage:latest
+
+COPY challenges/ciphers/challenges/letter-to-number/code/Letter-to-Number.py /home/player

--- a/images/challenges/ciphers/morse/Dockerfile
+++ b/images/challenges/ciphers/morse/Dockerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/acasi-ctf/ctf/penimage:latest
+
+COPY challenges/ciphers/challenges/morse-code/code/Morse_code.py /home/player

--- a/images/challenges/ciphers/reverse/Dockerfile
+++ b/images/challenges/ciphers/reverse/Dockerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/acasi-ctf/ctf/penimage:latest
+
+COPY challenges/ciphers/challenges/reverse-cipher/code/Reverse.py /home/player

--- a/images/penimage/Dockerfile
+++ b/images/penimage/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
 
 # Create the player user account
 RUN useradd -m player -s /bin/bash
+RUN echo "export PS1=\"shell> \"" > /home/player/.bashrc
 
 # This builds the keys that are necessary for sshd to start
 RUN service ssh start


### PR DESCRIPTION
This pull request separates each cipher challenge into its own container image.

Collaborated with @colbycocking on this.

# Closes issues
Closes #89.
Closes #126.

# Before
Each challenge used the same container image, resulting in having many files that weren't relevant to the challenge.

# After
Each challenge has its own image, and provides a cohesive experience to the user, not including files that are unnecessary for the task at hand.